### PR TITLE
Repl Code Lens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
 			"name": "Release Frege LSP",
 			"runtimeExecutable": "${execPath}",
 			"args": [
+				"--disable-extensions",
 				"--extensionDevelopmentPath=${workspaceRoot}",
 				"${workspaceFolder}/examples"
 			],

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VSCode language client for frege.
 1. Download the latest version `.vsix` file from [Releases](https://github.com/tricktron/frege-vscode/releases).
 2. Install the extension with `code --install-extension <path to downloaded extension.vsix>` or via the Command Palette (Ctrl/Cmd+Shift+P) `Install from VSIX...`.
 
-## Features
+## Language Server Features
 
 ### Diagnostics
 If you save or open a frege file with errros then the compiler warnings or errors are displayed in the problem tab of the extension host.
@@ -18,15 +18,19 @@ Whenever you hover over the first word of a line (which is usually a function), 
 
 ![hover](.img/frob-hover.png)
 
-### Run
+## Plugin Features
 
 #### Prerequisities
 
 - Gradle and Gradle wrapper. Run `gradle wrapper` in the Frege root project dir.
-- A Frege project setup with [Frege Gradle Plugin](https://github.com/tricktron/frege-gradle-plugin) >= 1.3.0. See [examples](./examples).
+- A Frege project setup with [Frege Gradle Plugin](https://github.com/tricktron/frege-gradle-plugin) >= 1.5.0. See [examples](./examples).
 
-If a Frege file contains a `main` function, then a code lens with `Run` appears. If you click on it, then the `main` function is executed.
+### Run & Repl Code Lens
 
+If a Frege file contains a `main` function, then a code lens with `Run` and `Repl` appears.
+
+- If you click on the `Run` Code Lens, then the `main` function is executed.
+- If you click on the `Repl` Code Lens, then the [Frege Repl](https://github.com/Frege/frege-repl) with all the specified dependencies is started in a new terminal. Also, it copies the command to load the current file to your clipboard so that you only need to paste it into the Repl for a blazingly fast experience:smiley:.
 
 ## How to Contribute
 - Add more tests and features:smiley:.

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'ch.fhnw.thga.frege' version '1.3.0-alpha'
+    id 'ch.fhnw.thga.frege' version '1.5.0-alpha'
 }
 
 frege {

--- a/examples/src/main/frege/ch/fhnw/thga/Test.fr
+++ b/examples/src/main/frege/ch/fhnw/thga/Test.fr
@@ -1,6 +1,10 @@
-module Test where
+module ch.fhnw.thga.Test where
 
 frobnicate a = (a, "Frege rocks")
+
+add a b = a + b
+
+square x = x * x
 
 main = do
   putStrLn "Hello World"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "VSCode lsp frege client",
 	"author": "Thibault Gagnaux",
 	"license": "SEE LICENSE IN LICENSE",
-	"version": "2.2.0-alpha",
+	"version": "2.3.0-alpha",
 	"publisher": "ch-fhnw-thga",
 	"repository": {
 		"type": "git",

--- a/src/mainCodeLensProvider.ts
+++ b/src/mainCodeLensProvider.ts
@@ -2,6 +2,7 @@ import { CancellationToken, CodeLens, CodeLensProvider, Event, ProviderResult, T
 import { findMainFunctionLineNumber, getFregeModuleName } from "./fregeCodeHelper";
 
 export const FREGE_RUN_CODELENS_COMMNAND = "frege-vscode.runCodeLens";
+export const FREGE_REPL_CODELENS_COMMNAND = "frege-vscode.replCodeLens";
 
 export class MainCodeLensProvider implements CodeLensProvider {
     onDidChangeCodeLenses?: Event<void>;
@@ -18,6 +19,11 @@ export class MainCodeLensProvider implements CodeLensProvider {
                 command: FREGE_RUN_CODELENS_COMMNAND,
                 tooltip: "Run Frege Program",
                 arguments: [`--mainModule=${moduleName}`]
+            }), new CodeLens(mainRange, {
+                title: "Repl",
+                command: FREGE_REPL_CODELENS_COMMNAND,
+                tooltip: "Start Frege Repl",
+                arguments: [document.uri.fsPath]
             }));
         }
     }

--- a/test/codeLens.test.ts
+++ b/test/codeLens.test.ts
@@ -13,7 +13,9 @@ describe('Can find the line number of the main function', () => {
                 println frob 2`;
         strictEqual(findMainFunctionLineNumber(fregeFileWithMainFunction), 3);
     });
+});
 
+describe('Return -1 as line number', () => {
     it('Given a frege file without a main function', () => {
         const fregeFileWithoutMainFunction =
             `module Test where
@@ -24,7 +26,7 @@ describe('Can find the line number of the main function', () => {
 });
 
 describe('Can extract the module name', () => {
-    it('Given a frege file', () => {
+    it('Given a frege file with a fully qualified module name (my.mod.Name)', () => {
         const fregeFile =
             `module my.mod.Name where
               main = do
@@ -32,15 +34,17 @@ describe('Can extract the module name', () => {
         strictEqual(getFregeModuleName(fregeFile), "my.mod.Name");
     });
 
-    it('Given a frege file with a single module name', () => {
+    it('Given a frege file with a single module name (Name)', () => {
         const fregeFile =
             `module Test where
               main = do
                 println "Frege rocks"`;
         strictEqual(getFregeModuleName(fregeFile), "Test");
     });
+});
 
-    it('Given a frege file with a no module name', () => {
+describe('Return an empty string', () => {
+    it('Given a frege file with no module name', () => {
         const fregeFile =
             `main = do
                 println "Frege rocks"`;


### PR DESCRIPTION
Adds a Repl Code Lens next to the Run Code Lens over the main function.

Clicking on the code lens does two things:
- Starts the Frege Repl with all dependencies using the https://github.com/tricktron/frege-gradle-plugin v.1.5.0-alpha.
- Copies the command `:l <path to the current file>` to the clipboard so that you can quickly load the current file into the Repl.