### PR TITLE
Fix: Include `language-configuration.json` in `.vsix` Package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,3 +2,4 @@
 !dist
 !syntaxes
 !LICENSE
+!language-configuration.json

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "VSCode lsp frege client",
 	"author": "Thibault Gagnaux",
 	"license": "SEE LICENSE IN LICENSE",
-	"version": "2.4.0-alpha",
+	"version": "2.4.1-alpha",
 	"publisher": "ch-fhnw-thga",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Include `language-configuration.json` in `vsix` package when running `vsce package`.