### PR TITLE
Update Frege Language Server to v4.0.0-alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ examples/build
 examples/lib
 examples/.project
 examples/gradle
+.frege-ls
+examples/.frege-ls

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'ch.fhnw.thga.frege' version '2.0.1-alpha'
+    id 'ch.fhnw.thga.frege' version '4.1.0-alpha'
 }
 
 frege {

--- a/examples/src/main/frege/ch/fhnw/thga/Dep.fr
+++ b/examples/src/main/frege/ch/fhnw/thga/Dep.fr
@@ -1,3 +1,7 @@
 module ch.fhnw.thga.Dep where
 
 square x = x * x
+
+mult a b = a * b
+
+minus a b = a - b

--- a/examples/src/main/frege/ch/fhnw/thga/ImportFailure.fr
+++ b/examples/src/main/frege/ch/fhnw/thga/ImportFailure.fr
@@ -1,0 +1,5 @@
+module ImportFailure where
+
+import ch.fhnw.thga.FaultyFregeTest
+
+main = println "Hello"

--- a/examples/src/main/frege/ch/fhnw/thga/Test.fr
+++ b/examples/src/main/frege/ch/fhnw/thga/Test.fr
@@ -8,7 +8,5 @@ add a b = a + b
 
 sub a b = a - b
 
-mult a b = a * b
-
 main = do
-  println $ frobnicate 5
+  println $ frobnicate (minus 5 3)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "VSCode lsp frege client",
 	"author": "Thibault Gagnaux",
 	"license": "SEE LICENSE IN LICENSE",
-	"version": "3.4.0-alpha",
+	"version": "4.0.0-alpha",
 	"publisher": "ch-fhnw-thga",
 	"repository": {
 		"type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import { FREGE_REPL_CODELENS_COMMNAND, FREGE_RUN_CODELENS_COMMNAND, MainCodeLens
 
 let client: LanguageClient;
 const FREGE_SERVER_NAME = 'frege-lsp-server';
-const FREGE_SERVER_VERSION = '3.4.0-alpha'
+const FREGE_SERVER_VERSION = '4.0.0-alpha'
 const DEFAULT_FREGE_SERVER_DIR = '.frege'
 const FREGE_RUN_TERMINAL_NAME = 'Frege Run';
 const FREGE_REPL_TERMINAL_NAME = 'Frege Repl';

--- a/test/downloadZip.test.ts
+++ b/test/downloadZip.test.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import { getFregeTarGithubUrl, downloadAndExtractTarFromUrl, getFregeStartScriptPath } from '../src/fregeServer';
 
 const fregeServerName = 'frege-lsp-server';
-const version = '3.4.0-alpha';
+const version = '4.0.0-alpha';
 
 const assertSystemPath = (actual: PathLike, expected: PathLike) => 
 {


### PR DESCRIPTION
Fixes #7 and fixes #8.

### New Features
- https://github.com/tricktron/frege-lsp-server/pull/37